### PR TITLE
docs: document helper script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ npm start
 
 The app listens on port 3000 by default. Visit `http://yourhost:3000` to view the splash page.
 
+## Script Usage
+
+Instead of running `npm start` directly, you can launch the server through the `dbox` helper script. This wrapper exposes a couple of handy flags:
+
+```bash
+# Run on a different port
+./dbox --port 8080
+
+# Enable production mode (sets NODE_ENV=production)
+./dbox --production
+
+# Flags can be combined
+./dbox --production --port 8080
+```
+
+Omit all flags to mimic `npm start` with default settings.
+
 ## Testing
 
 No automated tests are provided yet. A placeholder script runs when invoking:


### PR DESCRIPTION
## Summary
- document dbox helper script usage and options in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f2387df0c8328bd8c15ef441b3e68