### PR TITLE
Style navbar with active site highlighting

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -15,11 +15,29 @@ body {
   align-items: center;
 }
 
+.nav-sites {
+  flex: 1; /* Allow site links to fill available space */
+  display: flex;
+  justify-content: space-evenly; /* Evenly space site names */
+}
+
+.nav-auth {
+  margin-left: auto; /* Push auth links to the far right */
+}
+
 .navbar a {
   color: white;
   margin-right: 15px;
   text-decoration: none;
   font-weight: bold;
+}
+
+.nav-sites a {
+  margin-right: 0; /* Remove extra spacing for even distribution */
+}
+
+.navbar a.active {
+  border-bottom: 2px solid #fff; /* Highlight active site */
 }
 
 .content {

--- a/server.js
+++ b/server.js
@@ -72,7 +72,8 @@ app.get('/', (req, res) => {
   res.render('index', {
     sites,
     theme: config,
-    auth: req.session.authenticated
+    auth: req.session.authenticated,
+    currentSiteId: null // No site selected on splash page
   });
 });
 
@@ -85,12 +86,14 @@ app.get('/site/:id', (req, res) => {
     // If site not found, redirect to splash page
     return res.redirect('/');
   }
+  console.log(`Viewing site ${site.name} (${site.id})`); // Debug which site is requested
   res.render('site', {
     sites,
     site,
     host: req.hostname,
     theme: config,
-    auth: req.session.authenticated
+    auth: req.session.authenticated,
+    currentSiteId: site.id // Highlight selected site in navbar
   });
 });
 
@@ -102,7 +105,8 @@ app.get('/login', (req, res) => {
     sites,
     theme: config,
     error: null,
-    auth: req.session.authenticated
+    auth: req.session.authenticated,
+    currentSiteId: null // No site selected on login page
   });
 });
 
@@ -120,7 +124,8 @@ app.post('/login', (req, res) => {
     sites,
     theme: config,
     error: 'Invalid password',
-    auth: false
+    auth: false,
+    currentSiteId: null // No site selected on failed login
   });
 });
 
@@ -138,7 +143,8 @@ app.get('/admin', requireAuth, (req, res) => {
   res.render('admin', {
     sites,
     theme: config,
-    auth: true
+    auth: true,
+    currentSiteId: null // Admin page does not correspond to a site
   });
 });
 

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -1,4 +1,4 @@
-<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme}) %>
+<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme, currentSiteId: currentSiteId}) %><!-- Navbar with highlighting support -->
 <div class="content"><!-- Admin dashboard -->
   <h2>Add New Site</h2>
   <form method="post" action="/admin/site">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,4 +1,4 @@
-<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme}) %>
+<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme, currentSiteId: currentSiteId}) %><!-- Navbar with highlighting support -->
 <div class="content"><!-- Main landing page content -->
   <h1>Welcome to DisplayBox</h1>
   <table>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,4 +1,4 @@
-<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme}) %>
+<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme, currentSiteId: currentSiteId}) %><!-- Navbar with highlighting support -->
 <div class="content"><!-- Login form -->
   <h2>Admin Login</h2>
   <form method="post">

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -4,11 +4,13 @@
   /* Expose theme color to CSS as a variable */
   :root { --theme-color: <%= theme.themeColor %>; }
 </style>
-<div class="navbar">
-  <% sites.forEach(function(s){ %>
-    <a href="/site/<%= s.id %>"><%= s.name %></a>
-  <% }); %>
-  <div style="margin-left:auto;">
+<div class="navbar"><!-- Top navigation bar -->
+  <div class="nav-sites"><!-- Site links distributed evenly -->
+    <% sites.forEach(function(s){ %>
+      <a href="/site/<%= s.id %>" class="<%= currentSiteId === s.id ? 'active' : '' %>"><%= s.name %></a>
+    <% }); %>
+  </div>
+  <div class="nav-auth"><!-- Authentication links aligned to right -->
     <% if (auth) { %>
       <a href="/admin">Admin</a> | <a href="/logout">Logout</a>
     <% } else { %>

--- a/views/site.ejs
+++ b/views/site.ejs
@@ -1,2 +1,2 @@
-<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme}) %>
+<%- include('partials/navbar', {sites: sites, auth: auth, theme: theme, currentSiteId: currentSiteId}) %><!-- Navbar highlights current site -->
 <iframe src="http://<%= host %>:<%= site.port %>"></iframe><!-- Display selected site -->


### PR DESCRIPTION
## Summary
- evenly distribute site links and auth controls in the navbar
- highlight the current site tab
- pass selected site id from server for navbar state and log viewed site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891345e48a88328ba2d161491744320